### PR TITLE
draw mail count background with cairo

### DIFF
--- a/src/modules/ctypes/linux/cairo.jsm
+++ b/src/modules/ctypes/linux/cairo.jsm
@@ -25,6 +25,9 @@ function cairo_defines(lib) {
   lib.lazy_bind("cairo_rectangle", ctypes.void_t, this.cairo_t.ptr, ctypes.double, ctypes.double, ctypes.double, ctypes.double);
   lib.lazy_bind("cairo_set_source_rgb", ctypes.void_t, this.cairo_t.ptr, ctypes.double, ctypes.double, ctypes.double);
   lib.lazy_bind("cairo_fill", ctypes.void_t, this.cairo_t.ptr);
+  lib.lazy_bind("cairo_fill_preserve", ctypes.void_t, this.cairo_t.ptr);
+  lib.lazy_bind("cairo_set_line_width", ctypes.void_t, this.cairo_t.ptr, ctypes.double);
+  lib.lazy_bind("cairo_stroke", ctypes.void_t, this.cairo_t.ptr);
   lib.lazy_bind("cairo_move_to", ctypes.void_t, this.cairo_t.ptr, ctypes.double, ctypes.double);
   lib.lazy_bind("cairo_image_surface_create", this.cairo_surface_t.ptr, this.cairo_format_t, ctypes.int, ctypes.int);
   lib.lazy_bind("cairo_surface_destroy", ctypes.void_t, this.cairo_surface_t.ptr);

--- a/src/modules/linux/FiretrayGtkStatusIcon.jsm
+++ b/src/modules/linux/FiretrayGtkStatusIcon.jsm
@@ -233,20 +233,19 @@ firetray.Handler.setIconText = function(text, color) {
     //let dest = gdk.gdk_pixbuf_copy(specialIcon);
     //let w = gdk.gdk_pixbuf_get_width(specialIcon);
     //let h = gdk.gdk_pixbuf_get_height(specialIcon);
-    // above fails, draw light gray bordered square with cairo
-    var mysurface = cairo.cairo_image_surface_create(cairo.CAIRO_FORMAT_ARGB32, 32, 32);
-    var mycr = cairo.cairo_create(mysurface);
-    cairo.cairo_rectangle(mycr, 2, 2, 28, 28);
-    cairo.cairo_set_source_rgb(mycr, 0.85, 0.85, 0.85);
-    cairo.cairo_fill_preserve(mycr);
-
-    cairo.cairo_set_line_width(mycr, 2);
-    cairo.cairo_set_source_rgb(mycr, 0.4, 0.4, 0.4);
-    cairo.cairo_stroke(mycr);
-
-    let dest = gdk.gdk_pixbuf_get_from_surface(mysurface, 0, 0, 32, 32);
+    // workaround: loading from packed xpi fails, draw light gray bordered square with cairo
     let w = 32;
     let h = 32;
+    let stroke = 2;
+    var mysurface = cairo.cairo_image_surface_create(cairo.CAIRO_FORMAT_ARGB32, w, h);
+    var mycr = cairo.cairo_create(mysurface);
+    cairo.cairo_rectangle(mycr, stroke, stroke, w - (stroke * 2), h - (stroke * 2));
+    cairo.cairo_set_source_rgb(mycr, 0.85, 0.85, 0.85);
+    cairo.cairo_fill_preserve(mycr);
+    cairo.cairo_set_line_width(mycr, stroke);
+    cairo.cairo_set_source_rgb(mycr, 0.4, 0.4, 0.4);
+    cairo.cairo_stroke(mycr);
+    let dest = gdk.gdk_pixbuf_get_from_surface(mysurface, 0, 0, w, h);
     // prepare colors/alpha
 /* FIXME: draw everything with cairo when dropping gtk2 support. Use
  gdk_pixbuf_get_from_surface(). */

--- a/src/modules/linux/FiretrayGtkStatusIcon.jsm
+++ b/src/modules/linux/FiretrayGtkStatusIcon.jsm
@@ -228,12 +228,25 @@ firetray.Handler.setIconText = function(text, color) {
 
   try {
     // build background from image
-    let specialIcon = gdk.gdk_pixbuf_new_from_file(
-      firetray.GtkStatusIcon.FILENAME_BLANK, null); // GError **error);
-    let dest = gdk.gdk_pixbuf_copy(specialIcon);
-    let w = gdk.gdk_pixbuf_get_width(specialIcon);
-    let h = gdk.gdk_pixbuf_get_height(specialIcon);
+    //let specialIcon = gdk.gdk_pixbuf_new_from_file(
+    //  firetray.GtkStatusIcon.FILENAME_BLANK, null); // GError **error);
+    //let dest = gdk.gdk_pixbuf_copy(specialIcon);
+    //let w = gdk.gdk_pixbuf_get_width(specialIcon);
+    //let h = gdk.gdk_pixbuf_get_height(specialIcon);
+    // above fails, draw light gray bordered square with cairo
+    var mysurface = cairo.cairo_image_surface_create(cairo.CAIRO_FORMAT_ARGB32, 32, 32);
+    var mycr = cairo.cairo_create(mysurface);
+    cairo.cairo_rectangle(mycr, 2, 2, 28, 28);
+    cairo.cairo_set_source_rgb(mycr, 0.85, 0.85, 0.85);
+    cairo.cairo_fill_preserve(mycr);
 
+    cairo.cairo_set_line_width(mycr, 2);
+    cairo.cairo_set_source_rgb(mycr, 0.4, 0.4, 0.4);
+    cairo.cairo_stroke(mycr);
+
+    let dest = gdk.gdk_pixbuf_get_from_surface(mysurface, 0, 0, 32, 32);
+    let w = 32;
+    let h = 32;
     // prepare colors/alpha
 /* FIXME: draw everything with cairo when dropping gtk2 support. Use
  gdk_pixbuf_get_from_surface(). */


### PR DESCRIPTION
Just in case, you were interested in mail count (number) shown in tray - this works for me.
I admit, it's just a workaround and this is my first contribution to a Thunderbird extension.

I wasn't able to figure out, why using an existing image as background to compose fails in current TB. But drawing with cairo works.